### PR TITLE
[Fix] Layout Height

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -22,9 +22,10 @@ const Wrapper = styled.div`
   overflow-wrap: anywhere;
   justify-content: space-between;
   position: relative;
+  min-height: calc(100vh - 77px);
 
   ${onMobile} {
-    min-height: 95vh;
+    min-height: calc(100vh - 61px);
   }
 `;
 

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -51,7 +51,6 @@ const NavigationWrapper = styled(({ className, children }) => {
   );
 })`
   display: ${(props) => props.show ? 'block' : 'none'};
-  height: 100vh;
   top: 0;
   flex: 0 0 ${(props) => props.theme.layout.leftWidth};
   background: ${(props) => props.theme.navigationSidebar.backgroundPrimary};

--- a/src/components/TableOfContents/TableOfContents.js
+++ b/src/components/TableOfContents/TableOfContents.js
@@ -12,7 +12,6 @@ const Sidebar = styled.aside`
   background-color: ${(props) => props.theme.tableOfContents.background};
   display: ${(props) => props.show ? 'block' : 'none'};
   min-width: 260px;
-  height: 100vh;
   overflow: auto;
   padding: 50px 15px 0 5px;
   position: sticky;


### PR DESCRIPTION
# Scope of work

There have the glitches of height. When the contents of page are not too much or too tall, there would not make you scroll.
So, I have implement `min-height` which calculated with top navbar and remove unused height.

If you have any feedback or suggestion, please do not hesitate to ask me on this PR. 😁

Thank you,
World

# Commit Messsage
* fix: update min-height with calc and remove unused height