### PR TITLE
Fixed TOC link that can be linked to the content

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -71,6 +71,12 @@ const plugins = [
           },
         }, // End gatsby-remark-mermaid config
         {
+          resolve: require.resolve(`./plugins/gatsby-remark-sectionize-toc`),
+          options: {
+            maxDepth: config.features.toc.depth,
+          },
+        },
+        {
           resolve: "gatsby-remark-images",
           options: {
             maxWidth: 1035,


### PR DESCRIPTION
### Problem:

When the user clicked on Table of content, it'll not move to the target header content as in the screencast:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/3647850/113428864-c40d0d80-9401-11eb-821a-88de13132b3a.gif)

### Solution: 

add `h-` as a prefix of anchor link.