### PR TITLE
Make side menu and main content be scrollable independently

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -43,11 +43,6 @@ const MainContentScrollable = styled.div`
   display: flex;
   flex-direction: row;
   overflow-y: auto;
-  &:hover,
-  &:focus {
-    overflow-y: overlay;
-    -webkit-overflow-scrolling: touch;
-  }
 `;
 
 // We add min-width 1% to make flex-item not expand if it's child content wider than available space

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -29,6 +29,27 @@ const Wrapper = styled.div`
   }
 `;
 
+const MainContentWrapper = styled.div`
+  width: 100%;
+  flex-grow: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow-y: hidden;
+  min-height: 0;
+`;
+
+const MainContentScrollable = styled.div`
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: row;
+  overflow-y: auto;
+  &:hover,
+  &:focus {
+    overflow-y: overlay;
+    -webkit-overflow-scrolling: touch;
+  }
+`;
+
 // We add min-width 1% to make flex-item not expand if it's child content wider than available space
 const Content = styled('main')`
   min-width: 1%;
@@ -121,8 +142,12 @@ const Layout = ({ children, location }) => {
           ) : (
             ''
           )}
-          <Content>{children}</Content>
-          <TableOfContents show={! (config.features.fullScreenMode.hideToc && fullscreenMode)} location={location} css={hiddenTablet} />
+          <MainContentWrapper>
+            <MainContentScrollable>
+              <Content>{children}</Content>
+              <TableOfContents show={! (config.features.fullScreenMode.hideToc && fullscreenMode)} location={location} css={hiddenTablet} />
+            </MainContentScrollable>
+          </MainContentWrapper>
         </Wrapper>
       </MDXProvider>
     </ThemeProvider>

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -10,7 +10,7 @@ import { onMobile } from '../../styles/responsive';
 
 const Sidebar = styled.div`
   margin-left: ${(props) => props.theme.layout.leftMargin};
-  height: 100%;
+  height: calc(100vh - 100px);
   display: flex;
   overflow-y: hidden;
   align-items: stretch;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -35,6 +35,9 @@ const SidebarMain = styled.div`
     overflow-y: overlay;
     -webkit-overflow-scrolling: touch;
   }
+  ${onMobile} {
+    flex: 0 1 auto;
+  }
 `;
 
 const PoweredByWrapper = styled.div`

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -11,6 +11,7 @@ import { onMobile } from '../../styles/responsive';
 const Sidebar = styled.div`
   margin-left: ${(props) => props.theme.layout.leftMargin};
   height: 100%;
+  min-height: 0;
   display: flex;
   overflow-y: hidden;
   align-items: stretch;
@@ -28,8 +29,6 @@ const SidebarMain = styled.div`
   display: block;
   padding: 0;
   padding-top: 32px;
-  overflow: hidden;
-  -webkit-overflow-scrolling: hidden;
   &:hover,
   &:focus {
     overflow-y: overlay;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -10,7 +10,7 @@ import { onMobile } from '../../styles/responsive';
 
 const Sidebar = styled.div`
   margin-left: ${(props) => props.theme.layout.leftMargin};
-  height: calc(100vh - 100px);
+  height: 100%;
   display: flex;
   overflow-y: hidden;
   align-items: stretch;
@@ -21,6 +21,7 @@ const Sidebar = styled.div`
 `;
 
 const SidebarMain = styled.div`
+  flex: 1 1 0;
   overflow-y: auto;
   width: 100%;
   margin: 0;
@@ -37,6 +38,7 @@ const SidebarMain = styled.div`
 `;
 
 const PoweredByWrapper = styled.div`
+  flex: 0 1 auto;
   display: block;
   padding: 0;
   position: relative;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -29,11 +29,6 @@ const SidebarMain = styled.div`
   display: block;
   padding: 0;
   padding-top: 32px;
-  &:hover,
-  &:focus {
-    overflow-y: overlay;
-    -webkit-overflow-scrolling: touch;
-  }
   ${onMobile} {
     flex: 0 1 auto;
   }

--- a/src/components/Sidebar/poweredBy.js
+++ b/src/components/Sidebar/poweredBy.js
@@ -15,6 +15,7 @@ const Trademark = styled(({ className, trademark }) => {
       color: ${(props) => props.theme.navigationSidebar.poweredBy.hover};
     }
     width: 25px;
+    height: 25px;
   }
 `;
 const PoweredText = styled(({ className, text }) => (


### PR DESCRIPTION
To resolve #18.

The problem is the sidebar do not show scrollbar when menus overflow even we have put `flex` style.
`flex` should make it happen gratefully as below, but it not somehow. 

<img width="1759" alt="image" src="https://user-images.githubusercontent.com/12830900/114554122-91300880-9c90-11eb-9744-d923629e5a35.png">

So I just use `vh` to specify height of parent component to force scroll bar appear if content overflow.
