### PR TITLE
add Prerequisite and Gatsby drawback on `why-gatsby` page

### DIFF
--- a/content/web-frameworks/gatsby/why-gatsby.md
+++ b/content/web-frameworks/gatsby/why-gatsby.md
@@ -5,6 +5,10 @@ editable: true
 showToc: true
 ---
 
+# Prerequisite
+- React
+- GraphQL (You can also read from the Gatsby Docs)
+
 # Consider to use Gatsby if:
 - You want to create your personal blog.
 - You want to create a website for a company, foundation, agency, meetup, group, organization that seldom update contents.
@@ -30,6 +34,17 @@ showToc: true
 - Easy to setup with GitHub Actions for continuous delivery.
   - [GitHub Action workflow for GitHub Pages](/programming-cookbook/github-actions/deploy-to-github-pages)
   - [GitHub Action workflow for CloudFlare Workers](/programming-cookbook/github-actions/deploy-to-cloudflare-workers)
+
+# Gatsby don't be suitable if:
+
+- The web admin is not a developer. To modify the content or design, it requires programming skill.
+- You want admin control panel to modify the content.
+- Your content will be changed quite often, it'll make difficult to modify the content when compare to use admin panel.
+  - If you want to update the content in mobile or public computer, it might not convenience. The computer requires specify tools such as an editor, git command etc.
+- You're sticky on the traditional technology like basic html and css renderer tools. Other tools will be suitable for you such as:
+  - [Jekyll](https://jekyllrb.com/) - for Ruby user
+  - [Eleventy](https://www.11ty.dev/) (11ty) for JavaScript/Node user (The concept almost closes to Jekyll)
+  - [Hugo](https://gohugo.io/) - for Go user
 
 # Other useful information
 - [Gatsby vs WordPress](https://www.gatsbyjs.com/features/cms/gatsby-vs-wordpress/)

--- a/content/web-frameworks/gatsby/why-gatsby.md
+++ b/content/web-frameworks/gatsby/why-gatsby.md
@@ -35,13 +35,13 @@ showToc: true
   - [GitHub Action workflow for GitHub Pages](/programming-cookbook/github-actions/deploy-to-github-pages)
   - [GitHub Action workflow for CloudFlare Workers](/programming-cookbook/github-actions/deploy-to-cloudflare-workers)
 
-# Gatsby don't be suitable if:
+# Gatsby isn't suitable if:
 
-- The web admin is not a developer. To modify the content or design, it requires programming skill.
-- You want admin control panel to modify the content.
-- Your content will be changed quite often, it'll make difficult to modify the content when compare to use admin panel.
-  - If you want to update the content in mobile or public computer, it might not convenience. The computer requires specify tools such as an editor, git command etc.
-- You're sticky on the traditional technology like basic html and css renderer tools. Other tools will be suitable for you such as:
+- The web admin is not a developer. To modify the content or design, it requires programming skills.
+- You want the admin control panel to modify the content.
+- Your content will be changed quite often, it's more difficult to modify content than using the admin control panel.
+  - If you want to update the content on a mobile or public computer, it might be not convenient. The computer requires specific tools such as an editor, git command, etc.
+- You rely on traditional technologies like basic HTML and CSS renderer tools. Other tools will be suitable for you such as:
   - [Jekyll](https://jekyllrb.com/) - for Ruby user
   - [Eleventy](https://www.11ty.dev/) (11ty) for JavaScript/Node user (The concept almost closes to Jekyll)
   - [Hugo](https://gohugo.io/) - for Go user


### PR DESCRIPTION
I've reviewed `why-gatsby` page. I think something is missing. I've decided to add the drawback to select Gatsby as the web framework tools. It might be beneficial for who are making the decision. As you can see in the screenshot below:

<img width="1440" alt="Screen Shot 2564-04-21 at 07 03 24" src="https://user-images.githubusercontent.com/3647850/115478281-fdea6a80-a26f-11eb-8422-6e4a3960465c.png">

Any suggestion is welcome, please review my pull request 😊  