### PR TITLE
Change markdown code block language to support c# lang following lib `prism-react-renderer`

### DIFF
--- a/content/programming-cookbook/logging/NLog.md
+++ b/content/programming-cookbook/logging/NLog.md
@@ -50,7 +50,7 @@ install-package NLog
 
 - Set up the main class.
 
-```c#
+```cs
   // Import NLog classes.
   using NLog;
 

--- a/content/programming-cookbook/logging/log4net.md
+++ b/content/programming-cookbook/logging/log4net.md
@@ -18,7 +18,7 @@ install-package log4net
 
 - Set up the main class.
 
-```c#
+```cs
   // Import log4net classes.
   using log4net;
   using log4net.Config;

--- a/content/programming-cookbook/visual-studio/json-to-csharp-classes.md
+++ b/content/programming-cookbook/visual-studio/json-to-csharp-classes.md
@@ -20,7 +20,7 @@ showToc: true
 ![Paste JSON As Classes](images/json-to-csharp-classes.png)
 
 ## Result
-```c#
+```cs
 using System;
 
 namespace Ex.Models

--- a/content/testing/fluent-assertions.md
+++ b/content/testing/fluent-assertions.md
@@ -7,7 +7,7 @@ showToc: true
 
 สมมติว่าเรามี Data Structure ดังนี้ คำถามคือเราจะ Assert อย่างไร
 
-```c#
+```cs
 public class Todo
 {
     public int ID  { get; set; }
@@ -54,7 +54,7 @@ public class TodoList
 
 2. เรียก `using FluentAssertions;` แล้วเราสามารถใช้งาน [FluentAssertions](https://www.nuget.org/packages/FluentAssertions) ได้เลย
 
-    ```c#
+    ```cs
     using Xunit;
     using FluentAssertions;
 
@@ -84,7 +84,7 @@ public class TodoList
                     Completed = false
                 }
             };
-            
+
             var result = todoList.GetTodoList();
             result.Should().BeEquivalentTo(expected);
         }

--- a/content/web-frameworks/orchard-core-cms/shape-in-orchard-core-cms.md
+++ b/content/web-frameworks/orchard-core-cms/shape-in-orchard-core-cms.md
@@ -75,11 +75,11 @@ However, this method requires a view model which sometime we don't need it.
 
 We can use other methods to create ShapeResult. For example:
 
-```c#
+```cs
 var shapeResult = Dynamic(nameof(FooPart)).Location("Detail", "Content");
 ```
 
-```c#
+```cs
 return Factory(
     nameof(FooPart),
     async context => await context.New.FooPart()

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "eslint-plugin-react": "7.21.4",
     "gatsby-plugin-remove-trailing-slashes": "2.3.11",
     "prettier": "2.0.5",
-    "prism-react-renderer": "1.1.1"
+    "prism-react-renderer": "1.1.1",
+    "prismjs": "^1.24.1"
   },
   "resolutions": {
     "gatsby-react-router-scroll": "3.0.3",

--- a/src/components/MdxComponents/codeBlock.js
+++ b/src/components/MdxComponents/codeBlock.js
@@ -1,8 +1,14 @@
 import * as React from 'react';
 import Highlight, { defaultProps } from 'prism-react-renderer';
+import Prism from "prism-react-renderer/prism";
 import theme from 'prism-react-renderer/themes/dracula';
 import Loadable from 'react-loadable';
 import LoadingProvider from './loading';
+
+/** Check if load Prism from browser or server */
+(typeof global !== "undefined" ? global : window).Prism = Prism;
+
+require("prismjs/components/prism-csharp");
 
 /** Removes the last token from a code example if it's empty. */
 function cleanTokens(tokens) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13601,6 +13601,11 @@ prism-react-renderer@^1.0.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.0.tgz#5ad4f90c3e447069426c8a53a0eafde60909cdf4"
   integrity sha512-GHqzxLYImx1iKN1jJURcuRoA/0ygCcNhfGw1IT8nPIMzarmKQ3Nc+JcG0gi8JXQzuh0C5ShE4npMIoqNin40hg==
 
+prismjs@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.1.tgz#c4d7895c4d6500289482fa8936d9cdd192684036"
+  integrity sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==
+
 probe-image-size@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-4.1.1.tgz#c836c53154b6dd04dbcf66af2bbd50087b15e1dc"


### PR DESCRIPTION
Replace markdown code block from `c#` to `cpp`, following the lib variables: https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js#L11

```js
module.exports = {
...
  cpp: true,
...
};
```

Please review my PR.

