### PR TITLE
Add .NET Bangkok Meetup in the friend-websites

### DIFF
--- a/content/data/friends-websites.yml
+++ b/content/data/friends-websites.yml
@@ -48,3 +48,7 @@
 - name: Thang Chung - GitHub Repository
   url: https://github.com/thangchung
   about: Codespace by cloud-native developer and architect guy from Vietnam
+
+- name: .NET Bangkok Meetup
+  url: https://www.meetup.com/dotnet-bkk
+  about: Montly meetup about .NET in Bangkok.

--- a/content/data/friends-websites.yml
+++ b/content/data/friends-websites.yml
@@ -51,4 +51,4 @@
 
 - name: .NET Bangkok Meetup
   url: https://www.meetup.com/dotnet-bkk
-  about: Montly meetup about .NET in Bangkok.
+  about: Monthly meetup about .NET in Bangkok.


### PR DESCRIPTION
In this PR we add .NET Bangkok Meetup https://www.meetup.com/dotnet-bkk/ on the list of friend websites.

![image](https://user-images.githubusercontent.com/5432753/126539628-15ae66bb-1211-42f9-b66b-6b996ad2a851.png)

The main changes are on: `friends-websites.yml`