### PR TITLE
fix: correct git info for latest modified page.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -49,10 +49,7 @@ const plugins = [
     },
   },
   {
-    resolve: `gatsby-transformer-gitinfo`,
-    options: {
-      include: /\.mdx?$/i, // Only .md files
-    },
+    resolve: `gatsby-transformer-gitinfo`
   },
   {
     resolve: 'gatsby-plugin-mdx',


### PR DESCRIPTION
#  Problem

![lastupdate-old](https://user-images.githubusercontent.com/3647850/128168205-4c699fce-784b-46e7-a6d5-c14b0c79e136.PNG)

# Solution

The existing config allow only `.mdx` files. I've followed doc: https://www.gatsbyjs.com/plugins/gatsby-transformer-gitinfo/

![image](https://user-images.githubusercontent.com/3647850/128168261-c3ddd5bb-2493-4f86-9e48-6e980252923e.png)

Note: still work only `.md` files, not support `.mdx` files. However, it's fine, most files are `.md`.


